### PR TITLE
fixed shortcuts that have apostrophes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@ const exec = require('child_process').exec
 const path = require('path')
 
 function getCommand (lnkFile) {
-  const normalizedFile = path.normalize(path.resolve(lnkFile))
+  const normalizedFile = path.normalize(path.resolve(lnkFile)).replace('\'','\'\'')
   const getCOM = `(New-Object -COM WScript.Shell)`
 
   return `${getCOM}.CreateShortcut('${normalizedFile}').TargetPath;`


### PR DESCRIPTION
The library wasn't working for things like "Tony's exe.lnk"